### PR TITLE
:wrench: Fixed repo, added apps

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ exec lorax --product=$iso_product \
             --add-template=$base_dir/lib/fedora-lorax-templates/ostree-based-installer/lorax-embed-flatpaks.tmpl \
             --add-template-var=flatpak_remote_name="AppCenter" \
             --add-template-var=flatpak_remote_url=https://flatpak.elementary.io/repo.flatpakrepo \
-            --add-template-var=flatpak_remote_refs="runtime/io.elementary.Platform/x86_64/6.1 app/org.gnome.Epiphany/x86_64/stable app/org.gnome.Evince/x86_64/stable app/org.gnome.FileRoller/x86_64/stable" \
+            --add-template-var=flatpak_remote_refs="runtime/io.elementary.Platform/x86_64/6.1 runtime/org.freedesktop.Platform.GL.default/x86_64/21.08 app/org.gnome.Epiphany/x86_64/stable app/org.gnome.Evince/x86_64/stable app/org.gnome.FileRoller/x86_64/stable" \
             --logfile=$working_dir/lorax.log \
             --tmp=$working_dir/tmp \
             --rootfs-size=8 \

--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ exec lorax --product=$iso_product \
             --add-template=$base_dir/lib/fedora-lorax-templates/ostree-based-installer/lorax-embed-flatpaks.tmpl \
             --add-template-var=flatpak_remote_name="AppCenter" \
             --add-template-var=flatpak_remote_url=https://flatpak.elementary.io/repo.flatpakrepo \
-            --add-template-var=flatpak_remote_refs="runtime/io.elementary.Platform/x86_64/6.1" \
+            --add-template-var=flatpak_remote_refs="runtime/io.elementary.Platform/x86_64/6.1 app/org.gnome.Evince/x86_64/stable app/org.gnome.FileRoller/x86_64/stable" \
             --logfile=$working_dir/lorax.log \
             --tmp=$working_dir/tmp \
             --rootfs-size=8 \

--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ exec lorax --product=$iso_product \
             --add-template=$base_dir/lib/fedora-lorax-templates/ostree-based-installer/lorax-embed-flatpaks.tmpl \
             --add-template-var=flatpak_remote_name="AppCenter" \
             --add-template-var=flatpak_remote_url=https://flatpak.elementary.io/repo.flatpakrepo \
-            --add-template-var=flatpak_remote_refs="io.elementary.Platform/x86_64/6.1" \
+            --add-template-var=flatpak_remote_refs="runtime/io.elementary.Platform/x86_64/6.1" \
             --logfile=$working_dir/lorax.log \
             --tmp=$working_dir/tmp \
             --rootfs-size=8 \

--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ exec lorax --product=$iso_product \
             --add-template=$base_dir/lib/fedora-lorax-templates/ostree-based-installer/lorax-embed-flatpaks.tmpl \
             --add-template-var=flatpak_remote_name="AppCenter" \
             --add-template-var=flatpak_remote_url=https://flatpak.elementary.io/repo.flatpakrepo \
-            --add-template-var=flatpak_remote_refs="runtime/io.elementary.Platform/x86_64/6.1 app/org.gnome.Evince/x86_64/stable app/org.gnome.FileRoller/x86_64/stable" \
+            --add-template-var=flatpak_remote_refs="runtime/io.elementary.Platform/x86_64/6.1 app/org.gnome.Epiphany/x86_64/stable app/org.gnome.Evince/x86_64/stable app/org.gnome.FileRoller/x86_64/stable" \
             --logfile=$working_dir/lorax.log \
             --tmp=$working_dir/tmp \
             --rootfs-size=8 \

--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ exec lorax --product=$iso_product \
             --add-template=$base_dir/lib/fedora-lorax-templates/ostree-based-installer/lorax-embed-flatpaks.tmpl \
             --add-template-var=flatpak_remote_name="AppCenter" \
             --add-template-var=flatpak_remote_url=https://flatpak.elementary.io/repo.flatpakrepo \
-            --add-template-var=flatpak_remote_refs="runtime/io.elementary.Platform/x86_64/6.1 runtime/org.freedesktop.Platform.GL.default/x86_64/21.08 app/org.gnome.Epiphany/x86_64/stable app/org.gnome.Evince/x86_64/stable app/org.gnome.FileRoller/x86_64/stable" \
+            --add-template-var=flatpak_remote_refs="runtime/io.elementary.Platform/x86_64/6.1 app/org.gnome.Evince/x86_64/stable app/org.gnome.FileRoller/x86_64/stable" \
             --logfile=$working_dir/lorax.log \
             --tmp=$working_dir/tmp \
             --rootfs-size=8 \

--- a/build.sh
+++ b/build.sh
@@ -81,16 +81,14 @@ exec lorax --product=$iso_product \
             --add-template-var=ostree_oskey=$iso_ostree_oskey \
             --add-template-var=ostree_install_ref=$iso_ostree_ref_install \
             --add-template-var=ostree_update_ref=$iso_ostree_ref_update \
+            --add-template=$base_dir/lib/fedora-lorax-templates/ostree-based-installer/lorax-embed-flatpaks.tmpl \
+            --add-template-var=flatpak_remote_name="AppCenter" \
+            --add-template-var=flatpak_remote_url=https://flatpak.elementary.io/repo.flatpakrepo \
+            --add-template-var=flatpak_remote_refs="io.elementary.Platform/x86_64/6.1" \
             --logfile=$working_dir/lorax.log \
             --tmp=$working_dir/tmp \
             --rootfs-size=8 \
             $working_dir/output
-
-            # BUG: Fails with "Can't check signature: public key not found"
-            #--add-template=$base_dir/lib/fedora-lorax-templates/ostree-based-installer/lorax-embed-flatpaks.tmpl \
-            #--add-template-var=flatpak_remote_name="AppCenter" \
-            #--add-template-var=flatpak_remote_url=https://flatpak.elementary.io/repo/ \
-            #--add-template-var=flatpak_remote_refs="io.elementary.Platform/x86_64/6.1" \
 
 echoc "$(write_emoji "🛡️")Correcting permissions for build directory..."
 real_user=$(get_sudo_user)


### PR DESCRIPTION
Added reference to the .flatpakrepo file and uncommented the Flatpak lines. Additionalls, added runtime flag before the elementary.Platform runtime as that is needed for the script to function properly. Lastly, added two AppCenter apps including Epiphany, as org.freedesktop.Platform.GL.default can also be provided by the AppCenter Repo.